### PR TITLE
Fix: treat FontForge error

### DIFF
--- a/lib/pdftohtml.js
+++ b/lib/pdftohtml.js
@@ -66,9 +66,17 @@ function pdftohtml (filename, outfile, options) {
 
       child.stderr.on('data', (data) => {
         error += data;
+
+        var lastLine = data.toString('utf8').split(/\r\n|\r|\n/g);
+        if (lastLine[0].match(/^internal err/i)) {
+          if (!child.killed) {
+            child.kill()
+          }
+          reject(error);
+        }
+
         if (self.options.progress
               && typeof self.options.progress === "function") {
-          var lastLine = data.toString('utf8').split(/\r\n|\r|\n/g);
           var ll = lastLine[lastLine.length - 2];
           var progress;
           if (ll) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdftohtmljs",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "url": "https://github.com/fagbokforlaget/pdftohtmljs/issues",
   "description": "PDF to HTML (pdf2htmlex) shell wrapper",
   "main": "index.js",


### PR DESCRIPTION
There is a bug in pdf2htmlEX that makes its process consume all available memory. This problem happens when FontForge, a dependency of pdf2htmlEX, has an offset bigger than 65535 bytes on one lookup.
This error can be detected when pdf2htmlEX/FontForge prints on
stderr the following message:
```
Internal Error: Attempt to output 65744 into a 16-bit field. It will be truncated and the file may not be useful.
```